### PR TITLE
Version: [runtime 1.4.1 stable] [async/await proper support]

### DIFF
--- a/projects/melon-runtime/MelonJS/MelonJS.csproj
+++ b/projects/melon-runtime/MelonJS/MelonJS.csproj
@@ -7,11 +7,11 @@
     <Nullable>enable</Nullable>
     <DebugType>portable</DebugType>
 	<AssemblyName>MelonJS</AssemblyName>
-	<AssemblyVersion>1.4.0</AssemblyVersion>
+	<AssemblyVersion>1.4.1</AssemblyVersion>
 	<SignAssembly>False</SignAssembly>
 	<PackageProjectUrl>https://github.com/MelonRuntime/MelonJS</PackageProjectUrl>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
-	<FileVersion>1.4.0</FileVersion>
+	<FileVersion>1.4.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/projects/melon-runtime/MelonJS/Properties/Resources.Designer.cs
+++ b/projects/melon-runtime/MelonJS/Properties/Resources.Designer.cs
@@ -62,7 +62,7 @@ namespace MelonJS.Properties {
         
         /// <summary>
         ///   Consulta uma cadeia de caracteres localizada semelhante a {
-        ///    &quot;presets&quot;: [&quot;@babel/preset-typescript&quot;]
+        ///    &quot;presets&quot;: [&quot;@babel/preset-typescript&quot;, &quot;@babel/preset-env&quot;]
         ///}.
         /// </summary>
         internal static string NewProjectBabelrc {
@@ -142,6 +142,7 @@ namespace MelonJS.Properties {
         ///  &quot;devDependencies&quot;: {
         ///    &quot;@babel/cli&quot;: &quot;latest&quot;,
         ///    &quot;@babel/core&quot;: &quot;latest&quot;,
+        ///    &quot;@babel/preset-env&quot;: &quot;latest&quot;,
         ///    &quot;@babel/preset-typescript&quot;: &quot;latest&quot;,
         ///    &quot;melon-types&quot;: &quot;latest&quot;,
         ///    &quot;webpack-cli&quot;: &quot;latest&quot;
@@ -173,9 +174,10 @@ namespace MelonJS.Properties {
         ///   Consulta uma cadeia de caracteres localizada semelhante a {
         ///    &quot;compilerOptions&quot;: {
         ///      &quot;outDir&quot;: &quot;build&quot;,
-        ///        &quot;types&quot;: [
-        ///          &quot;melon-types&quot;
-        ///        ]
+        ///      &quot;types&quot;: [
+        ///        &quot;melon-types&quot;
+        ///      ],
+        ///      &quot;lib&quot;: [ &quot;es2015&quot;, &quot;DOM&quot; ]
         ///    }
         ///}.
         /// </summary>

--- a/projects/melon-runtime/MelonJS/Properties/Resources.resx
+++ b/projects/melon-runtime/MelonJS/Properties/Resources.resx
@@ -119,7 +119,7 @@
   </resheader>
   <data name="NewProjectBabelrc" xml:space="preserve">
     <value>{
-    "presets": ["@babel/preset-typescript"]
+    "presets": ["@babel/preset-typescript", "@babel/preset-env"]
 }</value>
   </data>
   <data name="NewProjectEntryPoint" xml:space="preserve">
@@ -279,6 +279,7 @@ babel/
   "devDependencies": {
     "@babel/cli": "latest",
     "@babel/core": "latest",
+    "@babel/preset-env": "latest",
     "@babel/preset-typescript": "latest",
     "melon-types": "latest",
     "webpack-cli": "latest"
@@ -298,9 +299,10 @@ babel/
     <value>{
     "compilerOptions": {
       "outDir": "build",
-        "types": [
-          "melon-types"
-        ]
+      "types": [
+        "melon-types"
+      ],
+      "lib": [ "es2015", "DOM" ]
     }
 }</value>
   </data>

--- a/projects/melon-runtime/package.json
+++ b/projects/melon-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "melon-runtime",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "MelonJS",
   "type": "module",
   "keywords": ["runtime", "javascript", "typescript", "data", "dotnet", "fast"],


### PR DESCRIPTION
- Implemented `async/await` proper support in projects generated by `npx melon new [path?]`. Manual projects still need bundling using babel preset env or similar to run
- Related to [issue 24](https://github.com/MelonRuntime/MelonRuntime/issues/23)